### PR TITLE
changing source of test import statement

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,5 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import anemoi

--- a/tests/test_mast.py
+++ b/tests/test_mast.py
@@ -1,4 +1,4 @@
-import anemoi as an
+from context import anemoi as an
 import pandas as pd
 import numpy as np
 


### PR DESCRIPTION
I added the context.py file that points the import statement to the version of anemoi one directory up from the tests folder.
This change is reflected in the test_mast.py file by specifying the import anemoi statement as coming from context.py